### PR TITLE
Fix/location verification first login

### DIFF
--- a/src/Listeners/LogSuccessfulLogin.php
+++ b/src/Listeners/LogSuccessfulLogin.php
@@ -65,12 +65,19 @@ class LogSuccessfulLogin
             abort(403, $e->getMessage());
         }
 
-        $sessionId = $session?->session_id ?? session()->getId();
+        $sessionId = $session !== null ? $session->session_id : session()->getId();
         $deviceInfo = $this->fingerprintService->generate();
         $hash = $deviceInfo['hash'] ?? '';
         $location = $this->geoService->getLocation(request()->ip());
-        $isNewDevice = config('sentinel-log.notifications.new_device.enabled', false) &&
-            $this->fingerprintService->isNewDevice($event->user, $hash);
+
+        // Assess against historical data BEFORE recording this login.
+        // Once the row is inserted the same queries would always find the current
+        // login and produce wrong results (new-device / new-location would never fire).
+        $isNewDevice = config('sentinel-log.notifications.new_device.enabled', false)
+            && $this->fingerprintService->isNewDevice($event->user, $hash);
+
+        $isNewLocation = config('sentinel-log.location_verification.enabled', true)
+            && $this->locationVerificationService->isNewLocation($event->user, $location);
 
         $log = AuthenticationLog::create([
             'authenticatable_id' => $event->user->getKey(),
@@ -110,18 +117,16 @@ class LogSuccessfulLogin
             Notification::send($event->user, new NewDeviceLogin($log));
         }
 
-        if (config('sentinel-log.location_verification.enabled', true)) {
-            if ($this->locationVerificationService->isNewLocation($event->user, $location)) {
-                $verification = $this->locationVerificationService->create(
-                    user: $event->user,
-                    ip: request()->ip(),
-                    location: $location,
-                    deviceInfo: $deviceInfo,
-                    userAgent: request()->userAgent() ?? '',
-                    sessionId: $sessionId,
-                );
-                Notification::send($event->user, new NewLocationLogin($verification));
-            }
+        if ($isNewLocation) {
+            $verification = $this->locationVerificationService->create(
+                user: $event->user,
+                ip: request()->ip(),
+                location: $location,
+                deviceInfo: $deviceInfo,
+                userAgent: request()->userAgent() ?? '',
+                sessionId: $sessionId,
+            );
+            Notification::send($event->user, new NewLocationLogin($verification));
         }
 
         if ($session !== null) {

--- a/src/Services/LocationVerificationService.php
+++ b/src/Services/LocationVerificationService.php
@@ -27,10 +27,18 @@ class LocationVerificationService
             return false;
         }
 
-        return ! AuthenticationLog::where('authenticatable_id', $user->getKey())
+        $priorLogins = AuthenticationLog::where('authenticatable_id', $user->getKey())
             ->where('authenticatable_type', get_class($user))
             ->where('event_name', 'login')
-            ->where('is_successful', true)
+            ->where('is_successful', true);
+
+        // No login history at all — this is the user's first login, not a suspicious
+        // location change. There is no baseline to compare against.
+        if (! (clone $priorLogins)->exists()) {
+            return false;
+        }
+
+        return ! (clone $priorLogins)
             ->where('location->city', $city)
             ->where('location->country', $country)
             ->exists();

--- a/tests/Unit/AuthenticationLogTest.php
+++ b/tests/Unit/AuthenticationLogTest.php
@@ -13,18 +13,16 @@ describe('AuthenticationLogTest', function () {
     it('uses correct table name from config', function () {
         $model = new AuthenticationLog;
 
-        // Default table name
-        $this->assertEquals('authentication_logs', $model->getTable());
+        expect($model->getTable())->toBe('authentication_logs');
 
-        // Custom table name
         config(['sentinel-log.table_name' => 'custom_auth_logs']);
-        $this->assertEquals('custom_auth_logs', $model->getTable());
+        expect($model->getTable())->toBe('custom_auth_logs');
     });
 
     it('has correct fillable attributes', function () {
         $model = new AuthenticationLog;
 
-        $expectedFillable = [
+        expect($model->getFillable())->toBe([
             'authenticatable_id',
             'authenticatable_type',
             'session_id',
@@ -36,9 +34,7 @@ describe('AuthenticationLogTest', function () {
             'is_successful',
             'event_at',
             'cleared_at',
-        ];
-
-        $this->assertEquals($expectedFillable, $model->getFillable());
+        ]);
     });
 
     it('has correct cast attributes', function () {
@@ -52,39 +48,38 @@ describe('AuthenticationLogTest', function () {
             'cleared_at' => 'datetime',
         ];
 
-        $this->assertEquals($expectedCasts, array_intersect($expectedCasts, $model->getCasts()));
+        expect(array_intersect($expectedCasts, $model->getCasts()))->toBe($expectedCasts);
     });
 
     it('has correct relationship methods', function () {
         $model = new AuthenticationLog;
 
-        $this->assertInstanceOf(MorphTo::class, $model->authenticatable());
+        expect($model->authenticatable())->toBeInstanceOf(MorphTo::class);
 
         $sessionRelation = $model->session();
-        $this->assertInstanceOf(BelongsTo::class, $sessionRelation);
-        $this->assertInstanceOf(SentinelSession::class, $sessionRelation->getRelated());
-        $this->assertEquals('session_id', $sessionRelation->getForeignKeyName());
+        expect($sessionRelation)
+            ->toBeInstanceOf(BelongsTo::class)
+            ->and($sessionRelation->getRelated())->toBeInstanceOf(SentinelSession::class)
+            ->and($sessionRelation->getForeignKeyName())->toBe('session_id');
     });
 
     it('can set attributes', function () {
         $model = new AuthenticationLog;
 
-        $data = [
+        $model->fill([
             'event_name' => 'login',
             'ip_address' => '127.0.0.1',
             'user_agent' => 'PHPUnit Test',
             'device_info' => ['browser' => 'Test Browser'],
             'location' => ['country' => 'Test Country'],
             'is_successful' => true,
-        ];
+        ]);
 
-        $model->fill($data);
-
-        $this->assertEquals('login', $model->event_name);
-        $this->assertEquals('127.0.0.1', $model->ip_address);
-        $this->assertEquals('PHPUnit Test', $model->user_agent);
-        $this->assertEquals(['browser' => 'Test Browser'], $model->device_info);
-        $this->assertEquals(['country' => 'Test Country'], $model->location);
-        $this->assertTrue($model->is_successful);
+        expect($model->event_name)->toBe('login')
+            ->and($model->ip_address)->toBe('127.0.0.1')
+            ->and($model->user_agent)->toBe('PHPUnit Test')
+            ->and($model->device_info)->toBe(['browser' => 'Test Browser'])
+            ->and($model->location)->toBe(['country' => 'Test Country'])
+            ->and($model->is_successful)->toBeTrue();
     });
 });


### PR DESCRIPTION
🐛 fix(location-verification): assess new device/location before recording the login

isNewLocation() and isNewDevice() were called after AuthenticationLog::create(),
so their queries always found the current login in the DB — meaning new-location
emails never fired for returning users, and the first-login guard was absent.

- Move both assessments above AuthenticationLog::create() so queries only
  see historical data
- Add a first-login guard in isNewLocation(): return false when the user has
  no prior login history (no baseline to compare against)
- Remove the redundant config check from the notification block — $isNewLocation
  already encodes the enabled flag