### PR TITLE
🐛 fix(contracts): unify NotifiableWithFailedAttempt interface signatu…

### DIFF
--- a/src/Contracts/NotifiableWithFailedAttempt.php
+++ b/src/Contracts/NotifiableWithFailedAttempt.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Harryes\SentinelLog\Contracts;
+
+use Harryes\SentinelLog\Models\AuthenticationLog;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+interface NotifiableWithFailedAttempt extends Authenticatable
+{
+    public function notifyFailedAttempt(AuthenticationLog $log): void;
+}

--- a/src/Listeners/LogFailedLogin.php
+++ b/src/Listeners/LogFailedLogin.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Harryes\SentinelLog\Listeners;
 
+use Harryes\SentinelLog\Contracts\NotifiableWithFailedAttempt;
 use Harryes\SentinelLog\Models\AuthenticationLog;
 use Harryes\SentinelLog\Services\BruteForceProtectionService;
 use Harryes\SentinelLog\Services\DeviceFingerprintService;
 use Harryes\SentinelLog\Services\GeolocationService;
 use Illuminate\Auth\Events\Failed;
-use Illuminate\Contracts\Auth\Authenticatable;
 
 class LogFailedLogin
 {
@@ -50,20 +50,7 @@ class LogFailedLogin
         ]);
 
         if ($event->user instanceof NotifiableWithFailedAttempt) {
-            $event->user->notifyFailedAttempt($log->toArray());
+            $event->user->notifyFailedAttempt($log);
         }
     }
-}
-
-/**
- * Interface for users that can be notified of failed login attempts.
- */
-interface NotifiableWithFailedAttempt extends Authenticatable
-{
-    /**
-     * Notify the user of a failed login attempt.
-     *
-     * @param array<string, mixed> $data The authentication log data
-     */
-    public function notifyFailedAttempt(array $data): void;
 }


### PR DESCRIPTION
…re with trait

The interface was defined inline at the bottom of LogFailedLogin with notifyFailedAttempt(array $data), while the trait defined the same method as notifyFailedAttempt(AuthenticationLog $log). The type mismatch meant a User model using the trait never satisfied the instanceof check, so failed-attempt notifications silently never fired.

- Move interface to src/Contracts/NotifiableWithFailedAttempt.php where it belongs alongside TwoFactorAuthenticatable
- Align interface signature with the trait: accepts AuthenticationLog $log
- Update listener to pass $log directly instead of $log->toArray()
- Drop the unused Authenticatable import from the listener