### PR TITLE
🔥 fix(geolocation): remove dead Guzzle client constructor

### DIFF
--- a/src/Services/GeolocationService.php
+++ b/src/Services/GeolocationService.php
@@ -5,19 +5,11 @@ declare(strict_types=1);
 namespace Harryes\SentinelLog\Services;
 
 use Exception;
-use GuzzleHttp\Client;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
 class GeolocationService
 {
-    protected Client $client;
-
-    public function __construct()
-    {
-        $this->client = new Client(['base_uri' => 'http://ip-api.com/json/']);
-    }
-
     /**
      * Get geolocation data for an IP address.
      *


### PR DESCRIPTION
GeolocationService constructed a GuzzleHttp\Client instance in __construct() that was never used — all lookups already went through Laravel's Http facade. The dead property and constructor have been removed along with the unused import.