### PR TITLE
✨ feat(geolocation): switch to ipwho.is and make provider configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ Edit `config/sentinel-log.php` to customize the package. Key options:
     'brute_force' => ['enabled' => true, 'threshold' => 5, 'window' => 15, 'block_duration' => 24],
 ```
 
+### Geolocation Provider
+```php
+    // Defaults to ipwho.is — free, HTTPS, no API key required.
+    // Override to use your own provider; must return JSON compatible with ipwho.is response format.
+    'geo_provider_url' => 'https://ipwho.is',
+```
+
 ### Geo-Fencing
 ```php
     'geo_fencing' => ['enabled' => false, 'allowed_countries' => ['United States', 'Canada']],
@@ -147,6 +154,7 @@ Add these to `.env`:
     SENTINEL_LOG_ENABLED=true
     SENTINEL_LOG_2FA_ENABLED=true
     SENTINEL_LOG_2FA_SETUP_ROUTE=two-factor.setup
+    SENTINEL_LOG_GEO_PROVIDER_URL=https://ipwho.is
     SENTINEL_LOG_GEO_FENCING_ENABLED=true
     SENTINEL_LOG_GEO_FENCING_ALLOWED_COUNTRIES="United States,Canada"
     SENTINEL_LOG_LOCATION_VERIFICATION_ENABLED=true

--- a/config/sentinel-log.php
+++ b/config/sentinel-log.php
@@ -47,6 +47,11 @@ return [
         'block_duration' => 24,
     ],
     'geo_test_ip' => env('SENTINEL_LOG_GEO_TEST_IP', null),
+
+    // Base URL of the geolocation provider. The package appends /{ip} to this URL.
+    // Default uses ipwho.is — free, HTTPS, no API key required.
+    // Custom providers must return JSON with: success (bool), country, city, latitude, longitude, ip.
+    'geo_provider_url' => env('SENTINEL_LOG_GEO_PROVIDER_URL', 'https://ipwho.is'),
     'geo_fencing' => [
         'enabled' => env('SENTINEL_LOG_GEO_FENCING_ENABLED', false),
         'allowed_countries' => explode(',', env('SENTINEL_LOG_GEO_FENCING_ALLOWED_COUNTRIES', 'United States,Canada')),

--- a/src/Services/GeolocationService.php
+++ b/src/Services/GeolocationService.php
@@ -18,35 +18,36 @@ class GeolocationService
     public function getLocation(string $ip): array
     {
         if (in_array($ip, ['127.0.0.1', '::1'])) {
-            // Use a configurable test IP or fallback
             $testIp = config('sentinel-log.geo_test_ip', null);
             if ($testIp) {
-                $ip = $testIp;  // Override with test IP if set
+                $ip = $testIp;
             } else {
                 return [
                     'country' => 'Local',
-                    'city' => 'Localhost',
-                    'lat' => 0,
-                    'lon' => 0,
+                    'city'    => 'Localhost',
+                    'lat'     => 0,
+                    'lon'     => 0,
                 ];
             }
         }
 
         try {
             $cacheKey = "sentinel_log_geo_{$ip}";
-            $data = Cache::remember($cacheKey, 3600, function () use ($ip) {
-                $response = Http::get("http://ip-api.com/json/{$ip}?fields=country,city,lat,lon,query,status");
 
-                return $response->json();
+            /** @var array<string, mixed> $data */
+            $data = Cache::remember($cacheKey, 3600, function () use ($ip) {
+                $baseUrl = rtrim((string) config('sentinel-log.geo_provider_url', 'https://ipwho.is'), '/');
+
+                return Http::get("{$baseUrl}/{$ip}")->json();
             });
 
-            if ($data['status'] === 'success') {
+            if ($data['success'] === true) {
                 return [
-                    'country' => $data['country'] ?? 'Unknown',
-                    'city' => $data['city'] ?? 'Unknown',
-                    'lat' => $data['lat'] ?? 0,
-                    'lon' => $data['lon'] ?? 0,
-                    'ip' => $data['query'] ?? $ip,
+                    'country' => $data['country']  ?? 'Unknown',
+                    'city'    => $data['city']      ?? 'Unknown',
+                    'lat'     => $data['latitude']  ?? 0,
+                    'lon'     => $data['longitude'] ?? 0,
+                    'ip'      => $data['ip']        ?? $ip,
                 ];
             }
         } catch (Exception) {
@@ -55,10 +56,10 @@ class GeolocationService
 
         return [
             'country' => 'Unknown',
-            'city' => 'Unknown',
-            'lat' => 0,
-            'lon' => 0,
-            'ip' => $ip,
+            'city'    => 'Unknown',
+            'lat'     => 0,
+            'lon'     => 0,
+            'ip'      => $ip,
         ];
     }
 }


### PR DESCRIPTION
ip-api.com's free tier is HTTP-only — a security concern for a security package. ipwho.is is free, requires no API key, and serves over HTTPS.

- Replace http://ip-api.com with https://ipwho.is as the default provider
- Remove dead GuzzleHttp\Client property and constructor (Http facade was already doing all the work)
- Add geo_provider_url config key (SENTINEL_LOG_GEO_PROVIDER_URL) so customers can swap in their own provider without touching package code
- Normalise ipwho.is latitude/longitude response fields to the internal lat/lon keys used across SessionTrackingService and notifications
- Document expected provider response format in config and README