### PR TITLE
✨ feat(fingerprint): replace IP-based hash with persistent cookie token

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ Edit `config/sentinel-log.php` to customize the package. Key options:
 ### Notifications
 ```php
     'new_device' => ['enabled' => true, 'channels' => ['mail']],
-    'failed_attempt' => ['threshold' => 5, 'window' => 15],
+    'failed_attempt' => ['enabled' => true, 'threshold' => 3, 'window' => 60],
+    'session_hijacking' => ['enabled' => true, 'channels' => ['mail']],
 ```
 
 ### Two-Factor Authentication (2FA)
@@ -228,6 +229,28 @@ Handle SSO login in the client app:
 ```php
     Route::get('/sso/login', fn() => 'Logged in via SSO')->middleware('auth');
 ```
+
+### Device Recognition
+
+SentinelLog uses a **persistent cookie token** as the primary device identity signal — the same approach used by GitHub, Google, and Stripe.
+
+**How it works:**
+- On first login from a browser, a cryptographically random 64-character token is generated and stored in a long-lived `sentinel_device_token` cookie (2 years, HttpOnly, SameSite=Lax)
+- On every subsequent login, the cookie is read and looked up in the login history
+- If the token is not found → new device → `NewDeviceLogin` notification sent
+- If the token is found → recognised device → no notification
+
+**Why a cookie and not a header hash?**  
+Header-based hashes that include the IP address break for mobile users (WiFi ↔ cellular), dynamic IPs, and VPN users. The cookie token is stable across all of these. A secondary header hash (User-Agent + Accept-Language + Accept-Encoding) is still stored in `device_info` alongside the token for forensic reference.
+
+**To enable new device notifications**, set in config:
+```php
+'notifications' => [
+    'new_device' => ['enabled' => true, 'channels' => ['mail']],
+],
+```
+
+> **Upgrading from a previous version?** Existing login records have no `token` field in `device_info`. Each user will receive a single "new device" email on their first login after the upgrade — after which the cookie is set and recognition is stable.
 
 ### Session Management
 View active sessions:

--- a/src/Listeners/LogSuccessfulLogin.php
+++ b/src/Listeners/LogSuccessfulLogin.php
@@ -66,15 +66,15 @@ class LogSuccessfulLogin
         }
 
         $sessionId = $session !== null ? $session->session_id : session()->getId();
-        $deviceInfo = $this->fingerprintService->generate();
-        $hash = $deviceInfo['hash'] ?? '';
-        $location = $this->geoService->getLocation(request()->ip());
+        $deviceInfo  = $this->fingerprintService->generate();
+        $deviceToken = $deviceInfo['token'] ?? '';
+        $location    = $this->geoService->getLocation(request()->ip());
 
         // Assess against historical data BEFORE recording this login.
         // Once the row is inserted the same queries would always find the current
         // login and produce wrong results (new-device / new-location would never fire).
         $isNewDevice = config('sentinel-log.notifications.new_device.enabled', false)
-            && $this->fingerprintService->isNewDevice($event->user, $hash);
+            && $this->fingerprintService->isNewDevice($event->user, $deviceToken);
 
         $isNewLocation = config('sentinel-log.location_verification.enabled', true)
             && $this->locationVerificationService->isNewLocation($event->user, $location);

--- a/src/Services/DeviceFingerprintService.php
+++ b/src/Services/DeviceFingerprintService.php
@@ -7,9 +7,15 @@ namespace Harryes\SentinelLog\Services;
 use Harryes\SentinelLog\Models\AuthenticationLog;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cookie;
+use Illuminate\Support\Str;
 
 class DeviceFingerprintService
 {
+    private const COOKIE_NAME = 'sentinel_device_token';
+    private const COOKIE_LIFETIME = 60 * 24 * 365 * 2; // 2 years in minutes
+    private const TOKEN_LENGTH = 64;
+
     protected Request $request;
 
     public function __construct(Request $request)
@@ -18,66 +24,102 @@ class DeviceFingerprintService
     }
 
     /**
-     * Generate a simple fingerprint based on request headers.
+     * Generate a device fingerprint for the current request.
+     *
+     * The `token` field is the primary device identity signal — a random value
+     * persisted in a long-lived HttpOnly cookie, stable across IP and UA changes.
+     * The `hash` field is a secondary header-based signal stored for forensic use.
      *
      * @return array<string, mixed>
      */
     public function generate(): array
     {
-        $headers = $this->request->headers->all();
+        $headers   = $this->request->headers->all();
+        $userAgent = $headers['user-agent'][0] ?? '';
 
         return [
-            'browser' => $headers['user-agent'][0] ?? null,
+            'token'           => $this->getOrCreateToken(),
+            'browser'         => $userAgent ?: null,
             'accept_language' => $headers['accept-language'][0] ?? null,
             'accept_encoding' => $headers['accept-encoding'][0] ?? null,
-            'platform' => $this->guessPlatform($headers['user-agent'][0] ?? ''),
-            'hash' => $this->createHash(),
+            'platform'        => $this->guessPlatform($userAgent),
+            'hash'            => $this->createHash(),
         ];
     }
 
     /**
-     * Check if this is a new device based on fingerprint hash.
+     * Determine whether this device token has never been seen for this user.
+     * A new token means a genuinely new browser, device, or cleared cookies.
      */
-    public function isNewDevice(Authenticatable $user, string $hash): bool
+    public function isNewDevice(Authenticatable $user, string $token): bool
     {
         return ! AuthenticationLog::where('authenticatable_id', $user->getKey())
             ->where('authenticatable_type', get_class($user))
             ->where('is_successful', true)
-            ->where('device_info->hash', $hash)
+            ->where('device_info->token', $token)
             ->exists();
     }
 
     /**
-     * Guess the platform from the user agent.
+     * Read the device token from the incoming cookie.
+     * If absent, mint a cryptographically random token and queue it on the response
+     * as a long-lived, HttpOnly, SameSite=Lax cookie.
      */
-    protected function guessPlatform(string $userAgent): ?string
+    private function getOrCreateToken(): string
     {
-        if (stripos($userAgent, 'Windows') !== false) {
-            return 'Windows';
-        } elseif (stripos($userAgent, 'Mac') !== false) {
-            return 'MacOS';
-        } elseif (stripos($userAgent, 'Linux') !== false) {
-            return 'Linux';
-        } elseif (stripos($userAgent, 'Android') !== false) {
-            return 'Android';
-        } elseif (stripos($userAgent, 'iPhone') !== false || stripos($userAgent, 'iPad') !== false) {
-            return 'iOS';
+        $existing = $this->request->cookie(self::COOKIE_NAME);
+
+        if (is_string($existing) && strlen($existing) === self::TOKEN_LENGTH) {
+            return $existing;
         }
 
-        return null;
+        $token = Str::random(self::TOKEN_LENGTH);
+
+        Cookie::queue(
+            Cookie::make(
+                name: self::COOKIE_NAME,
+                value: $token,
+                minutes: self::COOKIE_LIFETIME,
+                path: '/',
+                domain: null,
+                secure: (bool) config('session.secure', false),
+                httpOnly: true,
+                raw: false,
+                sameSite: 'Lax',
+            )
+        );
+
+        return $token;
     }
 
     /**
-     * Create a unique hash for the device.
+     * Guess the platform from the user agent string.
+     */
+    protected function guessPlatform(string $userAgent): ?string
+    {
+        return match (true) {
+            stripos($userAgent, 'Android') !== false                                         => 'Android',
+            stripos($userAgent, 'iPhone') !== false || stripos($userAgent, 'iPad') !== false => 'iOS',
+            stripos($userAgent, 'Windows') !== false                                         => 'Windows',
+            stripos($userAgent, 'Mac') !== false                                             => 'MacOS',
+            stripos($userAgent, 'Linux') !== false                                           => 'Linux',
+            default                                                                          => null,
+        };
+    }
+
+    /**
+     * Build a secondary header-based fingerprint hash.
+     * IP address is intentionally excluded — it is network state, not device identity,
+     * and changes constantly for mobile users and dynamic-IP connections.
      */
     protected function createHash(): string
     {
-        $data = [
-            $this->request->ip(),
+        $data = array_filter([
             $this->request->userAgent(),
             $this->request->header('accept-language'),
-        ];
+            $this->request->header('accept-encoding'),
+        ]);
 
-        return md5(implode('|', array_filter($data)));
+        return md5(implode('|', $data));
     }
 }


### PR DESCRIPTION
Header-based hashes that include the IP address break for any user whose
IP changes — mobile users, dynamic DHCP, VPNs — producing false "new device"
emails on every login. Top-tier systems (GitHub, Google, Stripe) solve this
with a persistent device token in a long-lived cookie.

- Mint a 64-char random token on first login, stored in a 2-year HttpOnly
  SameSite=Lax cookie (sentinel_device_token); read it on every subsequent
  login — same device = same token regardless of IP or minor UA changes
- isNewDevice() now queries device_info->token instead of device_info->hash
- Remove IP from the secondary hash; add Accept-Encoding — hash is now
  UA + Accept-Language + Accept-Encoding, kept for forensic context only
- Refactor guessPlatform() chained if/elseif to a cleaner match expression
- Android/iOS checked before Linux/Mac to avoid false matches on mobile UAs
  (Android UA contains "Linux", iOS Safari UA contains "Mac")
