### PR TITLE
🐛 fix(brute-force): preserve IP blocks on successful login and handle…

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,31 @@ To prune expired, unactioned verification records:
     app(LocationVerificationService::class)->pruneExpired();
 ```
 
+## Scheduled Maintenance
+
+SentinelLog accumulates records over time. Add these to your scheduler to keep tables clean:
+
+```php
+// routes/console.php (Laravel 11+) or App\Console\Kernel (Laravel 10)
+use Harryes\SentinelLog\Services\BruteForceProtectionService;
+use Harryes\SentinelLog\Services\LocationVerificationService;
+
+Schedule::call(fn () => app(BruteForceProtectionService::class)->pruneExpired())
+    ->daily()
+    ->name('sentinel-log:prune-blocked-ips');
+
+Schedule::call(fn () => app(LocationVerificationService::class)->pruneExpired())
+    ->daily()
+    ->name('sentinel-log:prune-location-verifications');
+```
+
+| Method | What it cleans | Recommended frequency |
+|---|---|---|
+| `BruteForceProtectionService::pruneExpired()` | Expired IP block records from `sentinel_blocked_ips` | Daily |
+| `LocationVerificationService::pruneExpired()` | Expired unactioned location verification tokens | Daily |
+
+> **Note on IP blocks:** A blocked IP is considered inactive once its `expires_at` timestamp passes — no record deletion is needed for the block to stop working. `pruneExpired()` is purely a housekeeping concern.
+
 ## Contributing
 Submit issues or pull requests on GitHub. Feedback is welcome!
 

--- a/src/Services/BruteForceProtectionService.php
+++ b/src/Services/BruteForceProtectionService.php
@@ -69,11 +69,16 @@ class BruteForceProtectionService
         Cache::put($cacheKey, $attempts, now()->addMinutes($window));
 
         if ($attempts >= $threshold) {
-            BlockedIp::create([
-                'ip_address' => $ip,
-                'expires_at' => now()->addHours(config('sentinel-log.brute_force.block_duration', 24)),
-                'reason' => 'Excessive failed login attempts',
-            ]);
+            // updateOrCreate handles the case where an expired block record already
+            // exists for this IP — create() would throw a unique constraint violation.
+            BlockedIp::updateOrCreate(
+                ['ip_address' => $ip],
+                [
+                    'blocked_at' => now(),
+                    'expires_at' => now()->addHours(config('sentinel-log.brute_force.block_duration', 24)),
+                    'reason'     => 'Excessive failed login attempts',
+                ]
+            );
             Cache::forget($cacheKey);
             abort(403, 'Too many login attempts. Your IP is now blocked.');
         }
@@ -109,11 +114,26 @@ class BruteForceProtectionService
     }
 
     /**
-     * Clear brute force attempts after successful login.
+     * Reset the rolling failed-attempt counter for an IP after a successful login.
+     * The BlockedIp record is intentionally left intact — a block was imposed for
+     * suspicious activity and should expire on its own schedule, not be erased
+     * because the attacker eventually guessed the correct password.
      */
     public function clearAttempts(string $ip): void
     {
         Cache::forget("sentinel_brute_force_{$ip}");
-        BlockedIp::where('ip_address', $ip)->delete();
+    }
+
+    /**
+     * Delete expired block records.
+     * Wire this into your scheduler to keep the sentinel_blocked_ips table clean:
+     *
+     *   $schedule->call(fn () => app(BruteForceProtectionService::class)->pruneExpired())->daily();
+     */
+    public function pruneExpired(): int
+    {
+        return BlockedIp::whereNotNull('expires_at')
+            ->where('expires_at', '<', now())
+            ->delete();
     }
 }


### PR DESCRIPTION
… re-blocking

clearAttempts() was deleting BlockedIp records on every successful login, meaning an attacker who guessed the correct password after being blocked had their block silently erased. Additionally, checkBruteForce() used create() on a unique-constrained column — re-blocking an expired IP would throw a DB unique constraint violation.

- clearAttempts() now only clears the rolling cache counter; the BlockedIp record is left to expire naturally via expires_at
- checkBruteForce() uses updateOrCreate() so expired blocks are refreshed cleanly instead of throwing a unique constraint violation
- Add pruneExpired() for scheduled housekeeping of expired block records
- Add Scheduled Maintenance section to README with both prune methods and a note explaining that expiry is time-based, not deletion-based