### PR TITLE
🐛 fix(geo-fencing): prevent empty env var from blocking all logins

### DIFF
--- a/config/sentinel-log.php
+++ b/config/sentinel-log.php
@@ -54,7 +54,7 @@ return [
     'geo_provider_url' => env('SENTINEL_LOG_GEO_PROVIDER_URL', 'https://ipwho.is'),
     'geo_fencing' => [
         'enabled' => env('SENTINEL_LOG_GEO_FENCING_ENABLED', false),
-        'allowed_countries' => explode(',', env('SENTINEL_LOG_GEO_FENCING_ALLOWED_COUNTRIES', 'United States,Canada')),
+        'allowed_countries' => array_values(array_filter(explode(',', env('SENTINEL_LOG_GEO_FENCING_ALLOWED_COUNTRIES', 'United States,Canada')))),
     ],
     'sso' => [
         'enabled' => env('SENTINEL_LOG_SSO_ENABLED', false),


### PR DESCRIPTION
Setting SENTINEL_LOG_GEO_FENCING_ALLOWED_COUNTRIES= (empty string) caused explode() to return [''] — a single empty-string element. No real country name ever matched it, so every login was blocked with a 403 silently.

Wrap the explode() with array_filter() + array_values() so an empty env value produces [] instead of ['']. The existing empty-array guard in checkGeoFence() then correctly skips enforcement, making the feature a safe no-op when the env var is blank.