### PR TITLE
🔒 fix(critical): resolve 4 security and stability issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,9 @@ Attempts are automatically rate-limited, and IPs are blocked after exceeding the
 When a user logs in from a city/country they have never used before, SentinelLog automatically sends them a `NewLocationLogin` notification with two action links:
 
 - **Yes, this was me** — marks the location as verified and logs a `location_verified` event.
-- **No, deny this login** — marks the login as denied, logs a `location_denied` event, and immediately invalidates the session.
+- **No, deny this login** — opens a confirmation page showing the location and IP details. The user must click a confirm button which submits a `POST` request to revoke the session, logging a `location_denied` event.
+
+> **Why a confirmation step for denial?** Email security scanners (Outlook Safe Links, Apple Mail, Gmail) automatically follow every link in an email on delivery. Without a confirmation page, these scanners would revoke the user's session before they even read the email.
 
 The links expire after `token_ttl` minutes (default 30). No application code changes are required — the check runs inside the `LogSuccessfulLogin` listener on every login.
 

--- a/src/Http/Controllers/LocationVerificationController.php
+++ b/src/Http/Controllers/LocationVerificationController.php
@@ -6,6 +6,7 @@ namespace Harryes\SentinelLog\Http\Controllers;
 
 use Harryes\SentinelLog\Services\LocationVerificationService;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 
 class LocationVerificationController extends Controller
@@ -23,6 +24,69 @@ class LocationVerificationController extends Controller
 
         return redirect(config('sentinel-log.location_verification.redirect_after_verify', '/'))
             ->with('sentinel_success', 'Login location confirmed. Thank you!');
+    }
+
+    /**
+     * Show a confirmation page before denying the login.
+     * Using a GET for the deny action would allow email security scanners
+     * (Outlook Safe Links, Apple Mail, Gmail) to automatically follow the link
+     * on delivery and revoke the user's session before they even read the email.
+     * The GET route shows a confirmation form; the POST route performs the denial.
+     */
+    public function denyConfirm(string $token): Response|RedirectResponse
+    {
+        $record = $this->service->findPending($token);
+
+        if (! $record) {
+            return redirect(config('sentinel-log.location_verification.redirect_after_deny', '/'))
+                ->with('sentinel_error', 'This denial link is invalid or has already been used.');
+        }
+
+        $location = $record->location ?? [];
+        $city     = e($location['city'] ?? 'Unknown');
+        $country  = e($location['country'] ?? 'Unknown');
+        $ip       = e($record->ip_address ?? 'Unknown');
+        $postUrl  = route('sentinel-log.location.deny', $token);
+        $csrfToken = csrf_token();
+
+        $html = <<<HTML
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>Deny Login — Security Alert</title>
+            <style>
+                body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f7fafc; display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; }
+                .card { background: white; border-radius: 8px; box-shadow: 0 2px 12px rgba(0,0,0,.1); padding: 40px; max-width: 460px; width: 100%; }
+                h2 { color: #e53e3e; margin: 0 0 8px; }
+                p { color: #4a5568; line-height: 1.6; }
+                .meta { background: #fff5f5; border-left: 4px solid #e53e3e; padding: 12px 16px; border-radius: 4px; margin: 20px 0; font-size: 14px; color: #742a2a; }
+                .btn-deny { background: #e53e3e; color: white; border: none; padding: 12px 28px; border-radius: 6px; font-size: 16px; cursor: pointer; width: 100%; }
+                .btn-deny:hover { background: #c53030; }
+                .cancel { display: block; text-align: center; margin-top: 14px; color: #718096; font-size: 14px; text-decoration: none; }
+            </style>
+        </head>
+        <body>
+            <div class="card">
+                <h2>Deny This Login?</h2>
+                <p>Someone logged in to your account from a location you have not used before.</p>
+                <div class="meta">
+                    <strong>Location:</strong> {$city}, {$country}<br>
+                    <strong>IP Address:</strong> {$ip}
+                </div>
+                <p>Confirming will <strong>immediately revoke that session</strong> and log a security event. If this was you, click Cancel instead.</p>
+                <form method="POST" action="{$postUrl}">
+                    <input type="hidden" name="_token" value="{$csrfToken}">
+                    <button type="submit" class="btn-deny">Yes, deny this login</button>
+                </form>
+                <a href="/" class="cancel">Cancel — this was me</a>
+            </div>
+        </body>
+        </html>
+        HTML;
+
+        return response($html);
     }
 
     public function deny(string $token): RedirectResponse

--- a/src/Listeners/LogSsoLogin.php
+++ b/src/Listeners/LogSsoLogin.php
@@ -52,23 +52,26 @@ class LogSsoLogin
         }
 
         // Log SSO event manually without re-triggering Auth::login()
-        $session = $this->sessionService->track($user);
-        $log = AuthenticationLog::create([
-            'authenticatable_id' => $user->getKey(),
+        try {
+            $session = $this->sessionService->track($user);
+        } catch (\Exception $e) {
+            abort(403, $e->getMessage());
+        }
+
+        $sessionId = $session !== null ? $session->session_id : session()->getId();
+
+        AuthenticationLog::create([
+            'authenticatable_id'   => $user->getKey(),
             'authenticatable_type' => get_class($user),
-            'session_id' => $session->session_id,
-            'event_name' => 'sso_login',
-            'ip_address' => request()->ip(),
-            'user_agent' => request()->userAgent(),
-            'device_info' => $this->fingerprintService->generate(),
-            'location' => $this->geoService->getLocation(request()->ip()),
-            'is_successful' => true,
+            'session_id'           => $sessionId,
+            'event_name'           => 'sso_login',
+            'ip_address'           => request()->ip(),
+            'user_agent'           => request()->userAgent(),
+            'device_info'          => $this->fingerprintService->generate(),
+            'location'             => $this->geoService->getLocation(request()->ip()),
+            'is_successful'        => true,
         ]);
 
         $this->bruteForceService->clearAttempts(request()->ip());
-
-        if ($user->isNewDevice($log->device_info['hash'] ?? '')) {
-            $user->notifyNewDevice($log);
-        }
     }
 }

--- a/src/Listeners/LogSuccessfulLogin.php
+++ b/src/Listeners/LogSuccessfulLogin.php
@@ -79,6 +79,10 @@ class LogSuccessfulLogin
         $isNewLocation = config('sentinel-log.location_verification.enabled', true)
             && $this->locationVerificationService->isNewLocation($event->user, $location);
 
+        // Geo-fence check must run BEFORE recording the login — otherwise a blocked
+        // user gets a is_successful = true audit entry before the abort fires.
+        $this->bruteForceService->checkGeoFence();
+
         $log = AuthenticationLog::create([
             'authenticatable_id' => $event->user->getKey(),
             'authenticatable_type' => get_class($event->user),
@@ -91,7 +95,6 @@ class LogSuccessfulLogin
             'is_successful' => true,
         ]);
 
-        $this->bruteForceService->checkGeoFence();
         $this->bruteForceService->clearAttempts(request()->ip());
 
         $user = $event->user;

--- a/src/Listeners/LogSuccessfulLogout.php
+++ b/src/Listeners/LogSuccessfulLogout.php
@@ -5,25 +5,18 @@ declare(strict_types=1);
 namespace Harryes\SentinelLog\Listeners;
 
 use Harryes\SentinelLog\Models\AuthenticationLog;
-use Harryes\SentinelLog\Services\DeviceFingerprintService;
 use Harryes\SentinelLog\Services\GeolocationService;
 use Harryes\SentinelLog\Services\SessionTrackingService;
 use Illuminate\Auth\Events\Logout;
 
 class LogSuccessfulLogout
 {
-    protected DeviceFingerprintService $fingerprintService;
-
     protected GeolocationService $geoService;
 
     protected SessionTrackingService $sessionService;
 
-    public function __construct(
-        DeviceFingerprintService $fingerprintService,
-        GeolocationService $geoService,
-        SessionTrackingService $sessionService
-    ) {
-        $this->fingerprintService = $fingerprintService;
+    public function __construct(GeolocationService $geoService, SessionTrackingService $sessionService)
+    {
         $this->geoService = $geoService;
         $this->sessionService = $sessionService;
     }
@@ -35,20 +28,18 @@ class LogSuccessfulLogout
         }
 
         $sessionId = session()->getId();
-        $session = $this->sessionService->track($event->user);
 
         AuthenticationLog::create([
-            'authenticatable_id' => $event->user->getKey(),
+            'authenticatable_id'   => $event->user->getKey(),
             'authenticatable_type' => get_class($event->user),
-            'session_id' => $sessionId,
-            'event_name' => 'logout',
-            'ip_address' => request()->ip(),
-            'user_agent' => request()->userAgent(),
-            'device_info' => $this->fingerprintService->generate(),
-            'location' => $this->geoService->getLocation(request()->ip()),
-            'is_successful' => true,
+            'session_id'           => $sessionId,
+            'event_name'           => 'logout',
+            'ip_address'           => request()->ip(),
+            'user_agent'           => request()->userAgent(),
+            'location'             => $this->geoService->getLocation(request()->ip()),
+            'is_successful'        => true,
         ]);
 
-        $session->delete(); // Clean up session record on logout
+        $this->sessionService->terminate($sessionId);
     }
 }

--- a/src/SentinelLogServiceProvider.php
+++ b/src/SentinelLogServiceProvider.php
@@ -45,8 +45,14 @@ class SentinelLogServiceProvider extends ServiceProvider
             Route::group(['middleware' => ['web'], 'prefix' => 'sentinel-log/location'], function () {
                 Route::get('verify/{token}', [LocationVerificationController::class, 'verify'])
                     ->name('sentinel-log.location.verify');
-                Route::get('deny/{token}', [LocationVerificationController::class, 'deny'])
+
+                // GET shows a confirmation page — prevents email scanners from auto-denying sessions
+                Route::get('deny/{token}', [LocationVerificationController::class, 'denyConfirm'])
                     ->name('sentinel-log.location.deny');
+
+                // POST performs the actual denial after the user confirms
+                Route::post('deny/{token}', [LocationVerificationController::class, 'deny'])
+                    ->name('sentinel-log.location.deny.confirm');
             });
         }
     }

--- a/src/Services/LocationVerificationService.php
+++ b/src/Services/LocationVerificationService.php
@@ -74,6 +74,17 @@ class LocationVerificationService
     }
 
     /**
+     * Find a pending verification record by token without actioning it.
+     * Used by the deny confirmation page to show location details before the user confirms.
+     */
+    public function findPending(string $token): ?LocationVerification
+    {
+        $record = LocationVerification::where('token', $token)->first();
+
+        return ($record && $record->isPending()) ? $record : null;
+    }
+
+    /**
      * Mark a verification token as verified.
      * Returns null if the token is invalid, expired, or already actioned.
      */

--- a/src/Services/SessionTrackingService.php
+++ b/src/Services/SessionTrackingService.php
@@ -73,6 +73,19 @@ class SessionTrackingService
     }
 
     /**
+     * Remove the sentinel session record for the given session ID on logout.
+     * Safe to call when session tracking is disabled — no-ops silently.
+     */
+    public function terminate(string $sessionId): void
+    {
+        if (! config('sentinel-log.sessions.enabled', true)) {
+            return;
+        }
+
+        SentinelSession::where('session_id', $sessionId)->delete();
+    }
+
+    /**
      * Check for potential session hijacking.
      *
      * @return array<string, mixed>|null


### PR DESCRIPTION
C-1 — LogSuccessfulLogout: calling track() during logout was semantically
wrong and crashed with null->delete() when sessions were disabled. Replaced
with a new terminate(sessionId) method on SessionTrackingService that safely
looks up and deletes the session record. Removed unnecessary fingerprintService
call that was queuing a device cookie on logout.

C-2 — LogSsoLogin: null session dereference and uncaught Exception from
track() when sessions disabled or max-sessions exceeded. Added try/catch and
null-safe sessionId fallback matching the pattern from LogSuccessfulLogin.

C-3 — LocationVerification deny route: the GET deny link was auto-triggered
by email security scanners (Outlook Safe Links, Apple Mail, Gmail), revoking
users' sessions before they read the email. GET now renders an inline
confirmation page; POST performs the actual denial. No Blade views required.
Added findPending() to LocationVerificationService for the confirmation page.

C-4 — LogSuccessfulLogin geo-fence order: checkGeoFence() was called after
AuthenticationLog::create(), recording a is_successful = true log entry for
users who were then blocked. Moved the check before the insert.
