### PR TITLE
🐛 fix: always register middleware aliases and correct view publish path

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,13 @@ Visit `http://localhost:8000` to explore the demo.
   php artisan vendor:publish --tag=sentinel-log-config
 ```
 
-2a. *(Optional)* **Publish Views** — to customise the verify/deny confirmation pages:
+2a. *(Optional)* **Publish Views** — only if you want to **customise** the verify/deny confirmation pages:
 ```bash
   php artisan vendor:publish --tag=sentinel-log-views
 ```
-This copies the Blade templates to `resources/views/vendor/sentinel-log/location/`.
+This copies the Blade templates to `resources/views/sentinel-log/location/`.
+
+> **Do not publish unless you intend to customise.** The package serves the confirmation pages automatically via `loadViewsFrom()` — no publishing step is required for them to work. Publishing a copy you never edit will silently shadow future package view updates.
 
 3. **Run Migrations**
 ```bash

--- a/src/SentinelLogServiceProvider.php
+++ b/src/SentinelLogServiceProvider.php
@@ -30,18 +30,18 @@ class SentinelLogServiceProvider extends ServiceProvider
         $this->publishes([__DIR__ . '/../config/sentinel-log.php' => config_path('sentinel-log.php')], 'sentinel-log-config');
         $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
         $this->loadViewsFrom(__DIR__ . '/../resources/views', 'sentinel-log');
-        $this->publishes([__DIR__ . '/../resources/views' => resource_path('views/vendor/sentinel-log')], 'sentinel-log-views');
+        $this->publishes([__DIR__ . '/../resources/views' => resource_path('views/sentinel-log')], 'sentinel-log-views');
         Event::listen(Login::class, LogSsoLogin::class);
         Event::listen(Login::class, LogSuccessfulLogin::class);
         Event::listen(Logout::class, LogSuccessfulLogout::class);
         Event::listen(Failed::class, LogFailedLogin::class);
 
-        if (config('sentinel-log.two_factor.enabled', false)) {
-            Route::aliasMiddleware('sentinel-log.2fa', EnforceTwoFactorAuthentication::class);
-        }
-        if (config('sentinel-log.geo_fencing.enabled', false)) {
-            Route::aliasMiddleware('sentinel-log.geofence', EnforceGeoFencing::class);
-        }
+        // Always register aliases — both middleware self-guard when their feature
+        // is disabled, so registering unconditionally is safe. Conditional registration
+        // caused "Target class does not exist" 500 errors when apps referenced the
+        // alias before enabling the feature in config.
+        Route::aliasMiddleware('sentinel-log.2fa', EnforceTwoFactorAuthentication::class);
+        Route::aliasMiddleware('sentinel-log.geofence', EnforceGeoFencing::class);
 
         if (config('sentinel-log.location_verification.enabled', true)) {
             Route::group(['middleware' => ['web'], 'prefix' => 'sentinel-log/location'], function () {


### PR DESCRIPTION
- Remove conditional if-blocks around Route::aliasMiddleware() for sentinel-log.2fa
  and sentinel-log.geofence — both middleware classes self-guard internally when
  their feature is disabled, so conditional registration was unnecessary and caused
  a fatal BindingResolutionException when apps referenced the alias in a route group
  before enabling the feature in config

- Fix vendor:publish --tag=sentinel-log-views destination from
  resources/views/vendor/sentinel-log to resources/views/sentinel-log

- Clarify in README that publishing views is strictly optional — the package
  serves confirmation pages automatically via loadViewsFrom() with no publish
  step required; only publish if you intend to customise the Blade templates
